### PR TITLE
Ajout de glow aléatoire ondulant

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,33 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Gradient Ring avec Pulse & Halo</title>
   <style>
-    /* ─── Couleur choisie dynamiquement par le script ─── */
+    /* ─── Propriétés enregistrées pour des transitions fluides ─── */
+    @property --x {
+      syntax: '<percentage>';
+      inherits: false;
+      initial-value: 50%;
+    }
+    @property --y {
+      syntax: '<percentage>';
+      inherits: false;
+      initial-value: 50%;
+    }
+    @property --fx {
+      syntax: '<length>';
+      inherits: false;
+      initial-value: 0px;
+    }
+    @property --fy {
+      syntax: '<length>';
+      inherits: false;
+      initial-value: 0px;
+    }
+    @property --rot {
+      syntax: '<angle>';
+      inherits: false;
+      initial-value: 0deg;
+    }
+
     :root {
       --clr: 165,41,255; /* valeur par défaut */
     }
@@ -21,8 +47,8 @@
       to   { transform: scale(1.8); opacity: 0; }
     }
     @keyframes flareScale {
-      from { transform: var(--pos) rotate(var(--rot)) scale(0.7); opacity: 1; }
-      to   { transform: var(--pos) rotate(var(--rot)) scale(1.4); opacity: 0; }
+      from { transform: scale(0.7); opacity: 1; }
+      to   { transform: scale(1.4); opacity: 0; }
     }
 
 
@@ -62,7 +88,8 @@
       /* currentColor = défini juste après */
       
       /* couleur de référence pour le halo */
-        color: rgb(var(--clr));
+        color: var(--clr);
+      transition: color 5s ease;
       }
 
       .wave {
@@ -76,6 +103,7 @@
         background: radial-gradient(circle at var(--x) var(--y), rgba(var(--clr),0.6), transparent 60%);
         animation: ripple 4s ease-out infinite;
         animation-delay: var(--delay, 0s);
+        transition: --x 5s ease, --y 5s ease;
       }
       .flare {
         position: absolute;
@@ -87,9 +115,17 @@
         pointer-events: none;
         mix-blend-mode: screen;
         background: radial-gradient(circle, rgba(var(--clr),0.9), transparent 70%);
-        --pos: translate(0,0);
+        --fx: 0px;
+        --fy: 0px;
         --rot: 0deg;
-        transform: var(--pos) rotate(var(--rot));
+        transform: translate(var(--fx), var(--fy)) rotate(var(--rot));
+        transition: --fx 5s ease, --fy 5s ease, --rot 5s ease;
+      }
+      .flare > div {
+        width: 100%;
+        height: 100%;
+        border-radius: inherit;
+        background: inherit;
         animation: flareScale 6s ease-out infinite;
         animation-delay: var(--delay, 0s);
       }
@@ -100,14 +136,14 @@
 
   <div class="gradient-ring-bg">
     <div class="wave"></div>
-    <div class="flare"></div>
-    <div class="flare"></div>
+    <div class="flare"><div></div></div>
+    <div class="flare"><div></div></div>
     <div class="wave"></div>
-    <div class="flare"></div>
-    <div class="flare"></div>
+    <div class="flare"><div></div></div>
+    <div class="flare"><div></div></div>
     <div class="wave"></div>
-    <div class="flare"></div>
-    <div class="flare"></div>
+    <div class="flare"><div></div></div>
+    <div class="flare"><div></div></div>
   </div>
 
   <script>
@@ -123,6 +159,8 @@
 
     function randomizeEffects() {
       const rgb = colors[Math.floor(Math.random() * colors.length)];
+      const color = `rgb(${rgb.join(',')})`;
+      ring.style.color = color;
       ring.style.setProperty('--clr', rgb.join(','));
       waves.forEach(wave => {
         const a = Math.random() * Math.PI * 2;
@@ -137,9 +175,10 @@
         const r = 190 + Math.random() * 20;
         const x2 = Math.cos(a2) * r;
         const y2 = Math.sin(a2) * r;
-        flare.style.setProperty("--pos", `translate(${x2}px, ${y2}px)`);
-        flare.style.setProperty("--rot", `${a2}rad`);
-        flare.style.setProperty("--delay", `-${Math.random() * 6}s`);
+        flare.style.setProperty('--fx', `${x2}px`);
+        flare.style.setProperty('--fy', `${y2}px`);
+        flare.style.setProperty('--rot', `${a2}rad`);
+        flare.style.setProperty('--delay', `-${Math.random() * 6}s`);
       });
     }
     randomizeEffects();

--- a/index.html
+++ b/index.html
@@ -5,10 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Gradient Ring avec Pulse & Halo</title>
   <style>
-    /* ─── Variables pour l’animation de teinte ─── */
-    :root {
-      --hue: 0deg;
-    }
+    /* ─── Aucune teinte dynamique : couleurs unifiées ─── */
 
     /* ─── keyframes pour le pulse ─── */
     @keyframes pulse {
@@ -46,8 +43,8 @@
         radial-gradient(
           circle at center,
           transparent 70%,
-          #A529FF 71%,
-          #8C00FF 85%,
+          currentColor 71%,
+          currentColor 85%,
           transparent 86%
         );
 
@@ -61,11 +58,7 @@
         inset 0 0 20px currentColor;
       /* currentColor = défini juste après */
       
-      /* rotation de teinte */
-      filter: hue-rotate(var(--hue));
-      transition: filter 5s ease-in-out;
-      
-      /* couleur de référence pour le halo (sera elle aussi hue-rotated) */
+      /* couleur de référence pour le halo */
         color: #A529FF;
       }
 
@@ -77,10 +70,9 @@
         border-radius: inherit;
         mix-blend-mode: screen;
         mask: radial-gradient(circle at center, transparent 69%, #000 70%, #000 86%, transparent 87%);
-        background: radial-gradient(circle at var(--x) var(--y), rgba(255,255,255,0.6), transparent 60%);
+        background: radial-gradient(circle at var(--x) var(--y), rgba(165,41,255,0.6), transparent 60%);
         animation: ripple 4s ease-out infinite;
         animation-delay: var(--delay, 0s);
-        filter: hue-rotate(var(--hue));
       }
       .flare {
         position: absolute;
@@ -91,8 +83,7 @@
         border-radius: 50%;
         pointer-events: none;
         mix-blend-mode: screen;
-        background: radial-gradient(circle, rgba(255,255,255,0.9), transparent 70%);
-        filter: hue-rotate(var(--hue));
+        background: radial-gradient(circle, rgba(165,41,255,0.9), transparent 70%);
         --pos: translate(0,0);
         --rot: 0deg;
         transform: var(--pos) rotate(var(--rot));
@@ -117,13 +108,10 @@
   </div>
 
   <script>
-    // Change la teinte et positionne les vagues de façon aléatoire toutes les 5 s
-    const root = document.documentElement;
+    // Positionne les vagues de façon aléatoire toutes les 5 s
     const waves = document.querySelectorAll('.wave');
 const flares = document.querySelectorAll('.flare');
     function randomizeEffects() {
-      const h = Math.floor(Math.random() * 360) + 'deg';
-      root.style.setProperty('--hue', h);
       waves.forEach(wave => {
         const a = Math.random() * Math.PI * 2;
         const x = 50 + Math.cos(a) * 38;

--- a/index.html
+++ b/index.html
@@ -20,6 +20,11 @@
       from { transform: scale(0.3); opacity: 0.8; }
       to   { transform: scale(1.8); opacity: 0; }
     }
+    @keyframes flareScale {
+      from { transform: var(--pos) rotate(var(--rot)) scale(0.7); opacity: 1; }
+      to   { transform: var(--pos) rotate(var(--rot)) scale(1.4); opacity: 0; }
+    }
+
 
     body {
       margin: 0;
@@ -77,21 +82,46 @@
         animation-delay: var(--delay, 0s);
         filter: hue-rotate(var(--hue));
       }
+      .flare {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        width: 30px;
+        height: 60px;
+        border-radius: 50%;
+        pointer-events: none;
+        mix-blend-mode: screen;
+        background: radial-gradient(circle, rgba(255,255,255,0.9), transparent 70%);
+        filter: hue-rotate(var(--hue));
+        --pos: translate(0,0);
+        --rot: 0deg;
+        transform: var(--pos) rotate(var(--rot));
+        animation: flareScale 6s ease-out infinite;
+        animation-delay: var(--delay, 0s);
+      }
+
   </style>
 </head>
 <body>
 
   <div class="gradient-ring-bg">
     <div class="wave"></div>
+    <div class="flare"></div>
+    <div class="flare"></div>
     <div class="wave"></div>
+    <div class="flare"></div>
+    <div class="flare"></div>
     <div class="wave"></div>
+    <div class="flare"></div>
+    <div class="flare"></div>
   </div>
 
   <script>
     // Change la teinte et positionne les vagues de façon aléatoire toutes les 5 s
     const root = document.documentElement;
     const waves = document.querySelectorAll('.wave');
-    function randomizeHueAndWaves() {
+const flares = document.querySelectorAll('.flare');
+    function randomizeEffects() {
       const h = Math.floor(Math.random() * 360) + 'deg';
       root.style.setProperty('--hue', h);
       waves.forEach(wave => {
@@ -102,9 +132,18 @@
         wave.style.setProperty('--y', y + '%');
         wave.style.setProperty('--delay', `-${Math.random() * 4}s`);
       });
+      flares.forEach(flare => {
+        const a2 = Math.random() * Math.PI * 2;
+        const r = 190 + Math.random() * 20;
+        const x2 = Math.cos(a2) * r;
+        const y2 = Math.sin(a2) * r;
+        flare.style.setProperty("--pos", `translate(${x2}px, ${y2}px)`);
+        flare.style.setProperty("--rot", `${a2}rad`);
+        flare.style.setProperty("--delay", `-${Math.random() * 6}s`);
+      });
     }
-    randomizeHueAndWaves();
-    setInterval(randomizeHueAndWaves, 5000);
+    randomizeEffects();
+    setInterval(randomizeEffects, 5000);
   </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -8,12 +8,6 @@
     /* ─── Variables pour l’animation de teinte ─── */
     :root {
       --hue: 0deg;
-      --wave1-x: 50%;
-      --wave1-y: 50%;
-      --wave2-x: 50%;
-      --wave2-y: 50%;
-      --wave3-x: 50%;
-      --wave3-y: 50%;
     }
 
     /* ─── keyframes pour le pulse ─── */
@@ -22,9 +16,9 @@
       50%      { transform: scale(1.1); opacity: 0.7; }
     }
 
-    @keyframes waves {
-      from { transform: rotate(0deg); }
-      to   { transform: rotate(360deg); }
+    @keyframes ripple {
+      from { transform: scale(0.3); opacity: 0.8; }
+      to   { transform: scale(1.8); opacity: 0; }
     }
 
     body {
@@ -70,38 +64,45 @@
         color: #A529FF;
       }
 
-      .gradient-ring-bg::before {
+      .wave {
         content: '';
         position: absolute;
         inset: 0;
-        border-radius: inherit;
         pointer-events: none;
-        background:
-          radial-gradient(circle at var(--wave1-x) var(--wave1-y), rgba(255,255,255,0.4), transparent 60%),
-          radial-gradient(circle at var(--wave2-x) var(--wave2-y), rgba(255,255,255,0.4), transparent 60%),
-          radial-gradient(circle at var(--wave3-x) var(--wave3-y), rgba(255,255,255,0.4), transparent 60%);
+        border-radius: inherit;
         mix-blend-mode: screen;
-        animation: waves 8s linear infinite;
+        mask: radial-gradient(circle at center, transparent 69%, #000 70%, #000 86%, transparent 87%);
+        background: radial-gradient(circle at var(--x) var(--y), rgba(255,255,255,0.6), transparent 60%);
+        animation: ripple 4s ease-out infinite;
+        animation-delay: var(--delay, 0s);
         filter: hue-rotate(var(--hue));
       }
   </style>
 </head>
 <body>
 
-  <div class="gradient-ring-bg"></div>
+  <div class="gradient-ring-bg">
+    <div class="wave"></div>
+    <div class="wave"></div>
+    <div class="wave"></div>
+  </div>
 
   <script>
-    // Change la teinte et les positions des waves toutes les 5s
+    // Change la teinte et positionne les vagues de façon aléatoire toutes les 5 s
     const root = document.documentElement;
+    const waves = document.querySelectorAll('.wave');
     function randomizeHueAndWaves() {
       const h = Math.floor(Math.random() * 360) + 'deg';
       root.style.setProperty('--hue', h);
-      for (let i = 1; i <= 3; i++) {
-        root.style.setProperty(`--wave${i}-x`, Math.floor(Math.random() * 100) + '%');
-        root.style.setProperty(`--wave${i}-y`, Math.floor(Math.random() * 100) + '%');
-      }
+      waves.forEach(wave => {
+        const a = Math.random() * Math.PI * 2;
+        const x = 50 + Math.cos(a) * 38;
+        const y = 50 + Math.sin(a) * 38;
+        wave.style.setProperty('--x', x + '%');
+        wave.style.setProperty('--y', y + '%');
+        wave.style.setProperty('--delay', `-${Math.random() * 4}s`);
+      });
     }
-    // Lance tout de suite, puis à chaque cycle de pulse
     randomizeHueAndWaves();
     setInterval(randomizeHueAndWaves, 5000);
   </script>

--- a/index.html
+++ b/index.html
@@ -54,18 +54,13 @@
 
     body {
       margin: 0;
-      height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
       background: #000;
-      overflow: hidden;
     }
 
   .gradient-ring-bg {
     position: relative;
-    width: 400px;
-    height: 400px;
+    width: 50vw;
+    height: 50vw;
     border-radius: 50%;
       /* l’anneau en radial-gradient */
       background:

--- a/index.html
+++ b/index.html
@@ -5,7 +5,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <title>Gradient Ring avec Pulse & Halo</title>
   <style>
-    /* ─── Aucune teinte dynamique : couleurs unifiées ─── */
+    /* ─── Couleur choisie dynamiquement par le script ─── */
+    :root {
+      --clr: 165,41,255; /* valeur par défaut */
+    }
 
     /* ─── keyframes pour le pulse ─── */
     @keyframes pulse {
@@ -59,7 +62,7 @@
       /* currentColor = défini juste après */
       
       /* couleur de référence pour le halo */
-        color: #A529FF;
+        color: rgb(var(--clr));
       }
 
       .wave {
@@ -70,7 +73,7 @@
         border-radius: inherit;
         mix-blend-mode: screen;
         mask: radial-gradient(circle at center, transparent 69%, #000 70%, #000 86%, transparent 87%);
-        background: radial-gradient(circle at var(--x) var(--y), rgba(165,41,255,0.6), transparent 60%);
+        background: radial-gradient(circle at var(--x) var(--y), rgba(var(--clr),0.6), transparent 60%);
         animation: ripple 4s ease-out infinite;
         animation-delay: var(--delay, 0s);
       }
@@ -83,7 +86,7 @@
         border-radius: 50%;
         pointer-events: none;
         mix-blend-mode: screen;
-        background: radial-gradient(circle, rgba(165,41,255,0.9), transparent 70%);
+        background: radial-gradient(circle, rgba(var(--clr),0.9), transparent 70%);
         --pos: translate(0,0);
         --rot: 0deg;
         transform: var(--pos) rotate(var(--rot));
@@ -109,9 +112,18 @@
 
   <script>
     // Positionne les vagues de façon aléatoire toutes les 5 s
+    const ring = document.querySelector('.gradient-ring-bg');
     const waves = document.querySelectorAll('.wave');
-const flares = document.querySelectorAll('.flare');
+    const flares = document.querySelectorAll('.flare');
+    const colors = [
+      [28,4,102],  // #1c0466
+      [207,32,247], // #cf20f7
+      [93,0,218]   // #5d00da
+    ];
+
     function randomizeEffects() {
+      const rgb = colors[Math.floor(Math.random() * colors.length)];
+      ring.style.setProperty('--clr', rgb.join(','));
       waves.forEach(wave => {
         const a = Math.random() * Math.PI * 2;
         const x = 50 + Math.cos(a) * 38;

--- a/index.html
+++ b/index.html
@@ -8,12 +8,23 @@
     /* ─── Variables pour l’animation de teinte ─── */
     :root {
       --hue: 0deg;
+      --wave1-x: 50%;
+      --wave1-y: 50%;
+      --wave2-x: 50%;
+      --wave2-y: 50%;
+      --wave3-x: 50%;
+      --wave3-y: 50%;
     }
 
     /* ─── keyframes pour le pulse ─── */
     @keyframes pulse {
       0%, 100% { transform: scale(1);   opacity: 1; }
       50%      { transform: scale(1.1); opacity: 0.7; }
+    }
+
+    @keyframes waves {
+      from { transform: rotate(0deg); }
+      to   { transform: rotate(360deg); }
     }
 
     body {
@@ -26,11 +37,11 @@
       overflow: hidden;
     }
 
-    .gradient-ring-bg {
-      position: relative;
-      width: 400px;
-      height: 400px;
-      border-radius: 50%;
+  .gradient-ring-bg {
+    position: relative;
+    width: 400px;
+    height: 400px;
+    border-radius: 50%;
       /* l’anneau en radial-gradient */
       background:
         radial-gradient(
@@ -56,8 +67,23 @@
       transition: filter 5s ease-in-out;
       
       /* couleur de référence pour le halo (sera elle aussi hue-rotated) */
-      color: #A529FF;
-    }
+        color: #A529FF;
+      }
+
+      .gradient-ring-bg::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        border-radius: inherit;
+        pointer-events: none;
+        background:
+          radial-gradient(circle at var(--wave1-x) var(--wave1-y), rgba(255,255,255,0.4), transparent 60%),
+          radial-gradient(circle at var(--wave2-x) var(--wave2-y), rgba(255,255,255,0.4), transparent 60%),
+          radial-gradient(circle at var(--wave3-x) var(--wave3-y), rgba(255,255,255,0.4), transparent 60%);
+        mix-blend-mode: screen;
+        animation: waves 8s linear infinite;
+        filter: hue-rotate(var(--hue));
+      }
   </style>
 </head>
 <body>
@@ -65,15 +91,19 @@
   <div class="gradient-ring-bg"></div>
 
   <script>
-    // Change --hue à une valeur aléatoire 0–360deg toutes les 5s
+    // Change la teinte et les positions des waves toutes les 5s
     const root = document.documentElement;
-    function randomizeHue() {
+    function randomizeHueAndWaves() {
       const h = Math.floor(Math.random() * 360) + 'deg';
       root.style.setProperty('--hue', h);
+      for (let i = 1; i <= 3; i++) {
+        root.style.setProperty(`--wave${i}-x`, Math.floor(Math.random() * 100) + '%');
+        root.style.setProperty(`--wave${i}-y`, Math.floor(Math.random() * 100) + '%');
+      }
     }
     // Lance tout de suite, puis à chaque cycle de pulse
-    randomizeHue();
-    setInterval(randomizeHue, 5000);
+    randomizeHueAndWaves();
+    setInterval(randomizeHueAndWaves, 5000);
   </script>
 
 </body>


### PR DESCRIPTION
## Résumé
- ajoute des variables CSS pour positionner des points lumineux
- anime un pseudo-élément qui affiche des ondes aléatoires
- met à jour le script pour générer la teinte et les positions des "waves" toutes les 5s

## Tests
- `npm test` *(échoue: `package.json` absent)*

------
https://chatgpt.com/codex/tasks/task_e_687808889f1c83249043494b20d8d2b5