### PR TITLE
Add interactive Spline viewer integration demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,78 +3,179 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>Gradient Ring avec Pulse & Halo</title>
+  <title>Demo Spline interactive</title>
+  <script type="module" src="https://unpkg.com/@splinetool/viewer@1.12.61/build/spline-viewer.js"></script>
   <style>
-    /* ─── Variables pour l’animation de teinte ─── */
     :root {
-      --hue: 0deg;
+      --bg: #05040b;
+      --card: rgba(15, 12, 28, 0.82);
+      --text: #f4f2ff;
+      --muted: #b7b2d2;
+      --accent: #ae73ff;
     }
 
-    /* ─── keyframes pour le pulse ─── */
-    @keyframes pulse {
-      0%, 100% { transform: scale(1);   opacity: 1; }
-      50%      { transform: scale(1.1); opacity: 0.7; }
-    }
+    * { box-sizing: border-box; }
 
     body {
       margin: 0;
-      height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: #000;
+      min-height: 100vh;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at top, #191039 0, var(--bg) 45%);
       overflow: hidden;
     }
 
-    .gradient-ring-bg {
+    .app {
       position: relative;
-      width: 400px;
-      height: 400px;
-      border-radius: 50%;
-      /* l’anneau en radial-gradient */
-      background:
-        radial-gradient(
-          circle at center,
-          transparent 70%,
-          #A529FF 71%,
-          #8C00FF 85%,
-          transparent 86%
-        );
+      min-height: 100vh;
+    }
 
-      /* pulse */
-      animation: pulse 5s ease-in-out infinite;
+    spline-viewer {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      background: transparent;
+    }
 
-      /* halo diffus autour */
-      box-shadow:
-        0 0 30px currentColor,
-        0 0 60px currentColor,
-        inset 0 0 20px currentColor;
-      /* currentColor = défini juste après */
-      
-      /* rotation de teinte */
-      filter: hue-rotate(var(--hue));
-      transition: filter 5s ease-in-out;
-      
-      /* couleur de référence pour le halo (sera elle aussi hue-rotated) */
-      color: #A529FF;
+    .overlay {
+      position: relative;
+      z-index: 2;
+      padding: 24px;
+      max-width: 420px;
+    }
+
+    .card {
+      background: var(--card);
+      border: 1px solid rgba(174, 115, 255, 0.35);
+      border-radius: 16px;
+      padding: 20px;
+      backdrop-filter: blur(10px);
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+    }
+
+    h1 {
+      margin: 0 0 10px;
+      font-size: 1.4rem;
+      line-height: 1.2;
+    }
+
+    p {
+      margin: 0 0 12px;
+      color: var(--muted);
+      line-height: 1.5;
+      font-size: 0.95rem;
+    }
+
+    ul {
+      margin: 10px 0 0;
+      padding-left: 18px;
+      color: var(--muted);
+      display: grid;
+      gap: 8px;
+      font-size: 0.92rem;
+    }
+
+    .actions {
+      margin-top: 16px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    button, a {
+      border: 0;
+      border-radius: 999px;
+      padding: 9px 14px;
+      background: rgba(174, 115, 255, 0.15);
+      color: var(--text);
+      cursor: pointer;
+      text-decoration: none;
+      font-size: 0.9rem;
+      transition: background 0.2s ease;
+    }
+
+    button:hover, a:hover {
+      background: rgba(174, 115, 255, 0.3);
+    }
+
+    .status {
+      margin-top: 12px;
+      font-size: 0.85rem;
+      color: #ddd3ff;
+      min-height: 20px;
+    }
+
+    .focus .overlay {
+      opacity: 0.15;
+      transition: opacity 0.25s ease;
+    }
+
+    .focus .overlay:hover {
+      opacity: 1;
+    }
+
+    @media (max-width: 600px) {
+      .overlay { padding: 16px; }
+      .card { padding: 16px; }
     }
   </style>
 </head>
 <body>
+  <main class="app" id="app">
+    <spline-viewer
+      id="splineScene"
+      url="https://prod.spline.design/HXiIXyaYlgX0VMAM/scene.splinecode"
+      loading-anim-type="spinner-small-dark"
+    ></spline-viewer>
 
-  <div class="gradient-ring-bg"></div>
+    <section class="overlay">
+      <div class="card">
+        <h1>Intégration Spline ✅</h1>
+        <p>
+          Oui, c'est très cool 👌 Tu peux intégrer la scène en quelques lignes et piloter
+          l'expérience avec des triggers dans Spline (hover, click, scroll, clavier, etc.).
+        </p>
+        <ul>
+          <li><strong>Clic + drag</strong> : tourner autour de l'objet (si Orbit activé).</li>
+          <li><strong>Molette</strong> : zoom avant/arrière.</li>
+          <li><strong>Clic</strong> : déclencher des événements configurés dans la scène.</li>
+          <li><strong>F</strong> : masquer/réafficher le panneau pour mode focus.</li>
+        </ul>
+        <div class="actions">
+          <button id="reloadBtn" type="button">Recharger la scène</button>
+          <a href="https://app.spline.design" target="_blank" rel="noreferrer noopener">Configurer les interactions</a>
+        </div>
+        <p class="status" id="status">Chargement de la scène…</p>
+      </div>
+    </section>
+  </main>
 
   <script>
-    // Change --hue à une valeur aléatoire 0–360deg toutes les 5s
-    const root = document.documentElement;
-    function randomizeHue() {
-      const h = Math.floor(Math.random() * 360) + 'deg';
-      root.style.setProperty('--hue', h);
-    }
-    // Lance tout de suite, puis à chaque cycle de pulse
-    randomizeHue();
-    setInterval(randomizeHue, 5000);
-  </script>
+    const app = document.getElementById('app');
+    const spline = document.getElementById('splineScene');
+    const status = document.getElementById('status');
+    const reloadBtn = document.getElementById('reloadBtn');
 
+    spline.addEventListener('load', () => {
+      status.textContent = 'Scène chargée. Astuce: crée des "Events" dans Spline pour des interactions custom.';
+    });
+
+    reloadBtn.addEventListener('click', () => {
+      const url = spline.getAttribute('url');
+      spline.setAttribute('url', '');
+      requestAnimationFrame(() => {
+        spline.setAttribute('url', url);
+        status.textContent = 'Scène rechargée.';
+      });
+    });
+
+    window.addEventListener('keydown', (event) => {
+      if (event.key.toLowerCase() === 'f') {
+        app.classList.toggle('focus');
+      }
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Replace the previous static decorative demo with an interactive, embeddable 3D viewer so the scene can be directly explored and controlled from the page. 
- Provide a small on-page UI that documents common interactions and demonstrates basic programmatic control (reload, focus). 
- Adjust layout and styling for a full-viewport Spline integration and a readable overlay card.

### Description
- Replaced the gradient ring demo with a full-page `<spline-viewer>` and included the Spline viewer script from the CDN to load the provided scene URL. 
- Added a glassmorphism overlay card (French text) containing interaction tips, a link to the Spline editor, and a `Recharger la scène` button that programmatically reloads the viewer URL. 
- Implemented client-side handlers for the viewer `load` event to update status text and a global `F` keyboard shortcut that toggles a focus mode which fades the overlay, and updated CSS for full-screen layout and overlay styling.

### Testing
- Served the site locally with `python3 -m http.server 4173` and confirmed the page responded successfully. 
- Executed a Playwright script visiting `http://127.0.0.1:4173` and saved a screenshot of the rendered page (artifact produced). 
- Ran `git diff --check` to validate no whitespace/errors and it completed without reported issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f221a8a24832481daebfb00e1f5b2)